### PR TITLE
General refactoring: +.editorconfig, typofixes, indentations, comment clarifications and portability

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,28 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{pl,pm}]
+indent_style = space
+indent_size = 4
+
+# perl tests (prove -l)
+[*.t]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+

--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@ please report any issues.
 
 ## How it works
 
-razorfy expects raw mails to be send to the TCP socket. razorfy checks the mail against the Razor packages and returns ham or spam
+razorfy expects raw mails to be sent to the TCP socket. razorfy checks the mail against the Razor packages and returns ham or spam.
 
 ## Future plans
 

--- a/razorfy.conf
+++ b/razorfy.conf
@@ -6,8 +6,8 @@ RAZORFY_DEBUG = 0
 # max number of threads to use  (Default 200)
 RAZORFY_MAXTHREADS = 200
 
-# bind razorfy default to local ip address (127.0.0.1)
-# use :: for all (dual stack), 0.0.0.0 (all ipv4), ::1 localhost v6only, 127.0.0.1 localhost ipv4
+# bind razorfy by default to v4only localhost address
+# use :: for all (dual stack), 0.0.0.0 for all (v4only), ::1 for localhost (v6only), 127.0.0.1 for localhost (v4only)
 RAZORFY_BINDADDRESS = 127.0.0.1
 
 # tcp port to use

--- a/razorfy.pl
+++ b/razorfy.pl
@@ -1,8 +1,8 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
-# Copyright (c) 2020, Mirko Ludeke <m.ludeke@heinlein-support.de>
-# Copyright (c) 2020, Carsten Rosenberg <c.rosenberg@heinlein-support.de>
-# Copyright (c) 2020, Andreas Boesen <boesen@belwue.de>
+# Copyright (c) 2023, Mirko Ludeke <m.ludeke@heinlein-support.de>
+# Copyright (c) 2023, Carsten Rosenberg <c.rosenberg@heinlein-support.de>
+# Copyright (c) 2023, Andreas Boesen <boesen@belwue.de>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,106 +25,120 @@ use Data::Dumper;
 use POSIX qw(setlocale strftime);
 use Razor2::Client::Agent;
 
+
 # set to 1 to enable debug logging
-my $debug = defined($ENV{'RAZORFY_DEBUG'}) ? $ENV{'RAZORFY_DEBUG'} : 0;
+my $debug       = defined($ENV{'RAZORFY_DEBUG'}) ? $ENV{'RAZORFY_DEBUG'} : 0;
+
 # max number of threa to use
-my $maxthreads = defined($ENV{'RAZORFY_MAXTHREADS'}) ? $ENV{'RAZORFY_MAXTHREADS'} : 200;
-# bind razorfy to default to local ip address
-# use :: for all (dual stack), 0.0.0.0 (all ipv4), ::1 localhost v6only, 127.0.0.1 localhost ipv4
+my $maxthreads  = defined($ENV{'RAZORFY_MAXTHREADS'}) ? $ENV{'RAZORFY_MAXTHREADS'} : 200;
+
+# bind razorfy by default to v4only localhost address
+# use :: for all (dual stack), 0.0.0.0 for all (v4only), ::1 for localhost (v6only), 127.0.0.1 for localhost (v4only)
 my $bindaddress = defined($ENV{'RAZORFY_BINDADDRESS'}) ? $ENV{'RAZORFY_BINDADDRESS'} : '127.0.0.1';
+
 # tcp port to use
-my $bindport 	= defined($ENV{'RAZORFY_BINDPORT'}) ? $ENV{'RAZORFY_BINDPORT'} : '11342';
+my $bindport    = defined($ENV{'RAZORFY_BINDPORT'}) ? $ENV{'RAZORFY_BINDPORT'} : '11342';
+
 
 my $agent = new Razor2::Client::Agent('razor-check') or die ;
-	$agent->read_options() 	or die $agent->errstr ."\n";
-	$agent->do_conf() 	or die $agent->errstr ."\n";
+    $agent->read_options() or die $agent->errstr ."\n";
+    $agent->do_conf()      or die $agent->errstr ."\n";
 
-my %logret = ( 0 => 'spam', 1 => 'ham');
+my %logret = ( 0 => 'spam', 1 => 'ham' );
 
 sub Main
 {
-	# flush after every write
-	$| = 1;
+    # flush after every write
+    $| = 1;
 
-	my ( $socket, $client_socket );
+    my ( $socket, $client_socket );
 
-	# Bind to listening address and port
-	$socket = new IO::Socket::IP (
-		LocalHost => $bindaddress,
-		LocalPort => $bindport,
-		Proto     => 'tcp',
-		Listen    => 10,
-		ReuseAddr => 1
-	) or die "Could not open socket: ".$!."\n";
+    # Bind to listening address and port
+    $socket = new IO::Socket::IP (
+        LocalHost => $bindaddress,
+        LocalPort => $bindport,
+        Proto     => 'tcp',
+        Listen    => 10,
+        ReuseAddr => 1
+    ) or die "Could not open socket: ".$!."\n";
 
-	ErrorLog( "RAZORFY started, PID: $$ Waiting for client connections...");
+    ErrorLog( "RAZORFY started, PID: $$ Waiting for client connections..." );
 
-	my @clients = ();
+    my @clients = ();
 
-	# start infinity loop
-	while(1)
-	{
+    # start infinity loop
+    while(1)
+    {
+        # Limit threads
+        my @threads = threads->list(threads::running);
 
-		# Limit threads
-		my @threads = threads->list(threads::running);
+        if( $#threads < $maxthreads )
+        {
+            # Waiting for new client connection.
+            $client_socket = $socket->accept();
 
-		if( $#threads < $maxthreads ) {
+            # Push new client connection to it's own thread
+            push ( @clients, threads->create( \&clientHandler, $client_socket ) );
 
-			# Waiting for new client connection.
-			$client_socket = $socket->accept();
+            ErrorLog(  "active threads: $#threads") if $debug ;
+            ErrorLog(  "client array length: " . scalar @clients) if $debug ;
 
-			# Push new client connection to it's own thread
-			push ( @clients, threads->create( \&clientHandler, $client_socket ) );
+            my $counter = 0;
+            foreach ( @clients )
+            {
+                if( $_->is_joinable() )
+                {
+                    $_->join();
+                }
 
-			ErrorLog(  "active threads: $#threads") if $debug ;
-			ErrorLog(  "client array length: " . scalar @clients) if $debug ;
+                if( not $_->is_running() )
+                {
+                    splice(@clients,$counter,1);
+                }
 
-			my $counter = 0;
-			foreach ( @clients )
-			{
-				if( $_->is_joinable() ) {
-		    	$_->join();
-		    }
-				if( not $_->is_running() ) {
-					splice(@clients,$counter,1);
-				}
-				$counter++;
-			}
-		}
-	}
-	$socket->close();
-	return 1;
+                $counter++;
+            }
+        }
+    }
+    $socket->close();
+    return 1;
 }
 
 sub clientHandler
 {
-	# Socket is passed to thread as first (and only) argument.
-	my ($client_socket) = @_;
+    # Socket is passed to thread as first (and only) argument.
+    my ($client_socket) = @_;
 
-	# Create hash for user connection/session information and set initial connection information.
-	my %user = ();
-    	$user{peer_address} = $client_socket->peerhost();
-	$user{peer_port} = $client_socket->peerport();
+    # Create hash for user connection/session information and set initial connection information.
+    my %user = ();
+    $user{peer_address} = $client_socket->peerhost();
+    $user{peer_port}    = $client_socket->peerport();
 
-	ErrorLog( "Accepted New Client Connection From:".$user{peer_address}.":".$user{peer_port}) if $debug;
+    ErrorLog( "Accepted New Client Connection From:".$user{peer_address}.":".$user{peer_port} ) if $debug;
 
-	my %hashr;
-	$hashr{'fh'} = $client_socket;
+    my %hashr;
+    $hashr{'fh'} = $client_socket;
 
-	my $ret = $agent->checkit(\%hashr);
-	print $client_socket ( $ret == 0) ? "spam" : "ham";
+    my $ret = $agent->checkit(\%hashr);
+    print $client_socket ( $ret == 0 ) ? "spam" : "ham";
 
-	ErrorLog( "return value: ". $logret{$ret} ) if $debug;
+    ErrorLog( "return value: ". $logret{$ret} ) if $debug;
 
-	$client_socket->shutdown(2);
-	threads->exit();
+    $client_socket->shutdown(2);
+    threads->exit();
 }
 
-sub ErrorLog {
-setlocale(&POSIX::LC_ALL, "en_US");
-  my $msg = shift;
-  my $datestring = strftime "%b %e %H:%M:%S", localtime;
-  print STDERR $msg."\n";
+sub ErrorLog
+{
+    # TODO:
+    # "my $datestring ..." is not used anymore in "print STDERR..." below.
+    # delete the line?
+    # also should the "setlocale(...);" line and the "use POSIX qw(setlocale strftime);" line at the top be removed as well?
+
+    setlocale(&POSIX::LC_ALL, "en_US");
+    my $msg = shift;
+    # my $datestring = strftime "%b %e %H:%M:%S", localtime;
+    print STDERR $msg."\n";
 }
 
 # Start the Main loop


### PR DESCRIPTION
* add initial .editorconfig file
  * Adding an .editorconfig file makes it easier to refactor.
  * As GitHub and lots of IDEs/Editors have native support
    for https://editorconfig.org/ files (and for others there
    are usually plugins) things like mixing tabs and spaces
    for indentation will hopefully be less likely in the future.
* typofixes in Readme.md
  * as other sentences in the Readme.md end with a full stop
    this one should also do so
  * s/to be send/to be sent/ (past participle)
* refactoring: razorfy.pl
  * use /usr/bin/env in shebang as this is more portable
  * update copyright date
  * clarify comment about $bindaddress
  * replace all tabs with spaces
  * make opening / closing braces consistent
* refactoring: razorfy.conf
  * clarify comment about RAZORFY_BINDADDRESS in config
