### PR TITLE
fix issue 2: Handle error from Razor2::Client::Agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+razor-agent.log

--- a/Readme.md
+++ b/Readme.md
@@ -59,6 +59,35 @@ Have a look to the commented razorfy.conf.
 
 Set `RAZORFY_DEBUG=1` and have a look to the logs `journalctl -u razorfy`
 
+# Development
+For development it's recommended to create a virtual environment with a thread capable perl using [perlbrew](https://perlbrew.pl/).
+
+## Initialize environment
+```
+perlbrew --notest install perl-5.38.2 --as=perl-5.38.2t -Dusethreads
+perlbrew lib create perl-5.38.2t@razorfy
+perlbrew use perl-5.38.2t@razorfy
+perlbrew install-cpanm
+cpanm --with-develop --installdeps .
+```
+
+## Enable environment in this terminal
+```
+perlbrew use perl-5.38.2t@razorfy
+```
+
+## Disable environment
+```
+perlbrew switch-off
+```
+
+## See if environment is set
+```
+perlbrew switch
+```
+
+
+
 # License
 
 Apache-2.0

--- a/Readme.md
+++ b/Readme.md
@@ -71,6 +71,9 @@ perlbrew install-cpanm
 cpanm --with-develop --installdeps .
 ```
 
+**Hint:** By using `perlbrew available` you can see the available Perl versions and adapt the previous commands if you wish to develop with another version of Perl.
+
+
 ## Enable environment in this terminal
 ```
 perlbrew use perl-5.38.2t@razorfy

--- a/cpanfile
+++ b/cpanfile
@@ -1,0 +1,12 @@
+requires 'IO::Socket::IP';
+requires 'IO::Select';
+requires 'Data::Dumper';
+requires 'Razor2::Syslog';
+requires 'Razor2::Client::Agent';
+
+on 'develop' => sub {
+    requires 'Term::ReadKey';
+    requires 'Term::ReadLine::Gnu';
+    requires 'Term::ReadLine::Perl';
+};
+

--- a/razorfy.conf
+++ b/razorfy.conf
@@ -12,3 +12,9 @@ RAZORFY_BINDADDRESS = 127.0.0.1
 
 # tcp port to use
 RAZORFY_BINDPORT = 11342
+
+# set bahaviour when razor (or Razor2::Client::Agent to be specific)
+# returns an error (EXIT_CODE 2) instead of ham or spam.
+# (Default ham)
+CLASSIFICATION_WHEN_RAZOR_ERRORS = ham
+

--- a/razorfy.conf
+++ b/razorfy.conf
@@ -13,8 +13,3 @@ RAZORFY_BINDADDRESS = 127.0.0.1
 # tcp port to use
 RAZORFY_BINDPORT = 11342
 
-# set bahaviour when razor (or Razor2::Client::Agent to be specific)
-# returns an error (EXIT_CODE 2) instead of ham or spam.
-# (Default ham)
-CLASSIFICATION_WHEN_RAZOR_ERRORS = ham
-

--- a/razorfy.pl
+++ b/razorfy.pl
@@ -22,7 +22,7 @@ use IO::Socket::IP;
 use IO::Select;
 use threads;
 use Data::Dumper;
-use POSIX qw(setlocale strftime);
+use POSIX qw(setlocale);
 use Razor2::Client::Agent;
 
 
@@ -130,14 +130,8 @@ sub clientHandler
 
 sub ErrorLog
 {
-    # TODO:
-    # "my $datestring ..." is not used anymore in "print STDERR..." below.
-    # delete the line?
-    # also should the "setlocale(...);" line and the "use POSIX qw(setlocale strftime);" line at the top be removed as well?
-
     setlocale(&POSIX::LC_ALL, "en_US");
     my $msg = shift;
-    # my $datestring = strftime "%b %e %H:%M:%S", localtime;
     print STDERR $msg."\n";
 }
 

--- a/razorfy.pl
+++ b/razorfy.pl
@@ -39,8 +39,6 @@ my $bindaddress = defined($ENV{'RAZORFY_BINDADDRESS'}) ? $ENV{'RAZORFY_BINDADDRE
 # tcp port to use
 my $bindport    = defined($ENV{'RAZORFY_BINDPORT'}) ? $ENV{'RAZORFY_BINDPORT'} : '11342';
 
-# How should emails be classsified if razor breaks?
-my $classification_when_razor_errors = defined($ENV{'CLASSIFICATION_WHEN_RAZOR_ERRORS'}) ? $ENV{'CLASSIFICATION_WHEN_RAZOR_ERRORS'} : 'ham';
 
 my $agent = new Razor2::Client::Agent('razor-check') or die ;
     $agent->read_options() or die $agent->errstr ."\n";
@@ -127,8 +125,8 @@ sub clientHandler
     # If Razor2::Client::Agent returned an error, usually EXIT_CODE 2 but to be sure classify everything except 0 and 1 as an error.
     if ( $ret > 1 or $ret < 0 )
     {
-        $string = $classification_when_razor_errors;
-        ErrorLog("Razor2::Client::Agent returned Error! See the Razor2::Client::Agent Log for details. EXIT_CODE of Razor2::Client::Agent equals '$ret'. The E-Mail has been classified as '$classification_when_razor_errors' as defined in your razorfy.conf");
+        $string = 'ham'; # always ham when razor fails to prevent a lot of false positives.
+        ErrorLog("Razor2::Client::Agent returned Error! See the Razor2::Client::Agent Log for details. EXIT_CODE of Razor2::Client::Agent equals '$ret'. The E-Mail has been classified as ham to prevent false positives.");
         $ret = 2;
     }
     else


### PR DESCRIPTION
* handle all possible return codes from `Razor2::Client::Agent` and classify emails as ham when razor is broken ( fixes issue #2 ).
* log the error, this makes sure that a debugging sysadmin is told to look at Razor instead of this script if Razor does not work properly
* make sure no undefined key is requested from the `%logret` hash
* add information about development to the readme and include a `cpanfile` so dependencies can be easily installed when developing
* add simple `.gitignore` file

edit: See commit message 0016b09ae198fff4a1f782178a146bc5a3683627